### PR TITLE
fix: Only apply .ToLower on properties that are strings

### DIFF
--- a/examples/controller/Dtos/UserDto.cs
+++ b/examples/controller/Dtos/UserDto.cs
@@ -16,4 +16,6 @@ public record UserDto
     public string UserName { get; set; } = string.Empty;
 
     public string Gender { get; set; } = string.Empty;
+
+    public int Age { get; set; }
 }

--- a/examples/controller/Entities/User.cs
+++ b/examples/controller/Entities/User.cs
@@ -23,4 +23,7 @@ public record User
 
     [Column("PersonSex", TypeName = "varchar(32)")]
     public string Gender { get; set; } = string.Empty;
+
+    [Column("Age", TypeName = "integer")]
+    public int Age { get; set; }
 }

--- a/examples/controller/Program.cs
+++ b/examples/controller/Program.cs
@@ -48,7 +48,8 @@ if (app.Environment.IsDevelopment())
                 .RuleFor(x => x.AvatarUrl, f => f.Internet.Avatar())
                 .RuleFor(x => x.UserName, f => f.Person.UserName)
                 .RuleFor(x => x.Gender, f => f.Person.Gender.ToString())
-                .RuleFor(x => x.IsDeleted, f => f.Random.Bool());
+                .RuleFor(x => x.IsDeleted, f => f.Random.Bool())
+                .RuleFor(x => x.Age, f => f.Random.Number(1, 10));
 
             context.Users.AddRange(users.Generate(1_000));
             context.SaveChanges();

--- a/src/Extensions/QueryableExtension.cs
+++ b/src/Extensions/QueryableExtension.cs
@@ -59,13 +59,19 @@ public static class QueryableExtension
                 {
                     where.Append($"{property}.{_filterOperations[operand]}({value})");
                 }
-                else
+                else if (typeof(T).GetProperties().FirstOrDefault(x => x.Name.Equals(property, StringComparison.OrdinalIgnoreCase))?.PropertyType == typeof(string))
                 {
                     where.Append($"{property}.ToLower() {_filterOperations[operand]} {value}.ToLower()");
                 }
+                else if (typeof(T).GetProperties().FirstOrDefault(x => x.Name.Equals(property, StringComparison.OrdinalIgnoreCase))?.PropertyType == typeof(Guid))
+                {
+                    where.Append($"{property} {_filterOperations[operand]} Guid({value})");
+                }
+                else
+                {
+                    where.Append($"{property} {_filterOperations[operand]} {value}");
+                }
             }
-
-            Console.WriteLine(where.ToString());
 
             result = result.Where(where.ToString());
         }

--- a/tests/TestDbContext.cs
+++ b/tests/TestDbContext.cs
@@ -14,6 +14,7 @@ public record User
 
     [Column("PersonSex", TypeName = "varchar(32)")]
     public string Gender { get; set; } = string.Empty;
+    public int Age { get; set; }
 }
 
 

--- a/tests/Tests.cs
+++ b/tests/Tests.cs
@@ -380,4 +380,30 @@ public class Tests : TestWithSqlite
 
         Assert.Equal(expectedSql, sql);
     }
+
+    [Fact]
+    public void Test_QueryWithFilterGuidEquals()
+    {
+        var query = new Query() { Filter = "id eq '7ac156a2-f938-43cb-8652-8b14a8b471de'" };
+
+        var (result, _) = _context.Users.AsQueryable().Apply(query, null);
+        var sql = result.ToQueryString();
+
+        var expectedSql = _context.Users.AsQueryable().Where(x => x.Id == new Guid("7ac156a2-f938-43cb-8652-8b14a8b471de")).ToQueryString();
+
+        Assert.Equal(expectedSql, sql);
+    }
+
+    [Fact]
+    public void Test_QueryWithFilterIntegerEquals()
+    {
+        var query = new Query() { Filter = "age eq 4" };
+
+        var (result, _) = _context.Users.AsQueryable().Apply(query, null);
+        var sql = result.ToQueryString();
+
+        var expectedSql = _context.Users.AsQueryable().Where(x => x.Age == 4).ToQueryString();
+
+        Assert.Equal(expectedSql, sql);
+    }
 }


### PR DESCRIPTION
- Added new integer property called `Age` for testing purposes
- Only apply `.ToLower()` if the property type is string
- If the property type is Guid, parse the string to a Guid and then do operand
- Added tests to cover both Integer and Guid