### PR TITLE
feat(filter): Added ability to only filter by date, instead of datetime

### DIFF
--- a/src/GoatQuery/src/Ast/Literals.cs
+++ b/src/GoatQuery/src/Ast/Literals.cs
@@ -76,6 +76,6 @@ public sealed class DateLiteral : QueryExpression
 
     public DateLiteral(Token token, DateTime value) : base(token)
     {
-        Value = value.Date;
+        Value = value;
     }
 }

--- a/src/GoatQuery/src/Ast/Literals.cs
+++ b/src/GoatQuery/src/Ast/Literals.cs
@@ -69,3 +69,13 @@ public sealed class DateTimeLiteral : QueryExpression
         Value = value;
     }
 }
+
+public sealed class DateLiteral : QueryExpression
+{
+    public DateTime Value { get; set; }
+
+    public DateLiteral(Token token, DateTime value) : base(token)
+    {
+        Value = value.Date;
+    }
+}

--- a/src/GoatQuery/src/Evaluator/FilterEvaluator.cs
+++ b/src/GoatQuery/src/Evaluator/FilterEvaluator.cs
@@ -51,6 +51,11 @@ public static class FilterEvaluator
                         case DateTimeLiteral literal:
                             value = Expression.Constant(literal.Value, property.Type);
                             break;
+                        case DateLiteral literal:
+                            property = Expression.Property(property, "Date");
+
+                            value = Expression.Constant(literal.Value.Date, property.Type);
+                            break;
                         default:
                             return Result.Fail($"Unsupported literal type: {exp.Right.GetType().Name}");
                     }

--- a/src/GoatQuery/src/Lexer/Lexer.cs
+++ b/src/GoatQuery/src/Lexer/Lexer.cs
@@ -64,6 +64,12 @@ public sealed class QueryLexer
 
                     if (IsDigit(token.Literal[0]))
                     {
+                        if (IsDate(token.Literal))
+                        {
+                            token.Type = TokenType.DATE;
+                            return token;
+                        }
+
                         if (IsDateTime(token.Literal))
                         {
                             token.Type = TokenType.DATETIME;
@@ -101,6 +107,11 @@ public sealed class QueryLexer
         ReadCharacter();
 
         return token;
+    }
+
+    private bool IsDate(string value)
+    {
+        return DateTime.TryParseExact(value, new[] { "yyyy-MM-dd" }, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal, out _);
     }
 
     private bool IsDateTime(string value)

--- a/src/GoatQuery/src/Parser/Parser.cs
+++ b/src/GoatQuery/src/Parser/Parser.cs
@@ -140,7 +140,7 @@ public sealed class QueryParser
 
         var statement = new InfixExpression(_currentToken, identifier, _currentToken.Literal);
 
-        if (!PeekTokenIn(TokenType.STRING, TokenType.INT, TokenType.GUID, TokenType.DATETIME, TokenType.DECIMAL, TokenType.FLOAT, TokenType.DOUBLE))
+        if (!PeekTokenIn(TokenType.STRING, TokenType.INT, TokenType.GUID, TokenType.DATETIME, TokenType.DECIMAL, TokenType.FLOAT, TokenType.DOUBLE, TokenType.DATE))
         {
             return Result.Fail("Invalid value type within filter");
         }
@@ -152,7 +152,7 @@ public sealed class QueryParser
             return Result.Fail("Value must be a string when using 'contains' operand");
         }
 
-        if (statement.Operator.In(Keywords.Lt, Keywords.Lte, Keywords.Gt, Keywords.Gte) && !CurrentTokenIn(TokenType.INT, TokenType.DECIMAL, TokenType.FLOAT, TokenType.DOUBLE, TokenType.DATETIME))
+        if (statement.Operator.In(Keywords.Lt, Keywords.Lte, Keywords.Gt, Keywords.Gte) && !CurrentTokenIn(TokenType.INT, TokenType.DECIMAL, TokenType.FLOAT, TokenType.DOUBLE, TokenType.DATETIME, TokenType.DATE))
         {
             return Result.Fail($"Value must be an integer when using '{statement.Operator}' operand");
         }
@@ -202,6 +202,12 @@ public sealed class QueryParser
                 if (DateTime.TryParse(_currentToken.Literal, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal, out var dateTimeValue))
                 {
                     statement.Right = new DateTimeLiteral(_currentToken, dateTimeValue);
+                }
+                break;
+            case TokenType.DATE:
+                if (DateTime.TryParse(_currentToken.Literal, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal, out var dateValue))
+                {
+                    statement.Right = new DateLiteral(_currentToken, dateValue);
                 }
                 break;
         }

--- a/src/GoatQuery/src/Token/Token.cs
+++ b/src/GoatQuery/src/Token/Token.cs
@@ -10,6 +10,7 @@ public enum TokenType
     DOUBLE,
     GUID,
     DATETIME,
+    DATE,
     LPAREN,
     RPAREN,
 }

--- a/src/GoatQuery/tests/Filter/FilterLexerTest.cs
+++ b/src/GoatQuery/tests/Filter/FilterLexerTest.cs
@@ -331,7 +331,7 @@ public sealed class FilterLexerTest
             {
                 new (TokenType.IDENT, "dateOfBirth"),
                 new (TokenType.IDENT, "eq"),
-                new (TokenType.DATETIME, "2000-01-01"),
+                new (TokenType.DATE, "2000-01-01"),
             }
         };
 
@@ -342,7 +342,7 @@ public sealed class FilterLexerTest
             {
                 new (TokenType.IDENT, "dateOfBirth"),
                 new (TokenType.IDENT, "lt"),
-                new (TokenType.DATETIME, "2000-01-01"),
+                new (TokenType.DATE, "2000-01-01"),
             }
         };
 
@@ -353,7 +353,7 @@ public sealed class FilterLexerTest
             {
                 new (TokenType.IDENT, "dateOfBirth"),
                 new (TokenType.IDENT, "lte"),
-                new (TokenType.DATETIME, "2000-01-01"),
+                new (TokenType.DATE, "2000-01-01"),
             }
         };
 
@@ -364,7 +364,7 @@ public sealed class FilterLexerTest
             {
                 new (TokenType.IDENT, "dateOfBirth"),
                 new (TokenType.IDENT, "gt"),
-                new (TokenType.DATETIME, "2000-01-01"),
+                new (TokenType.DATE, "2000-01-01"),
             }
         };
 
@@ -375,7 +375,7 @@ public sealed class FilterLexerTest
             {
                 new (TokenType.IDENT, "dateOfBirth"),
                 new (TokenType.IDENT, "gte"),
-                new (TokenType.DATETIME, "2000-01-01"),
+                new (TokenType.DATE, "2000-01-01"),
             }
         };
 

--- a/src/GoatQuery/tests/Filter/FilterTest.cs
+++ b/src/GoatQuery/tests/Filter/FilterTest.cs
@@ -175,6 +175,11 @@ public sealed class FilterTest
         };
 
         yield return new object[] {
+            "dateOfBirth eq 2020-05-09",
+            new[] { _users["Jane"] }
+        };
+
+        yield return new object[] {
             "dateOfBirth lt 2010-01-01",
             new[] { _users["John"], _users["Apple"], _users["Harry"], _users["Egg"] }
         };


### PR DESCRIPTION
This feature adds the ability to filter by just a date value, eg `2002-08-01` and it return every datetime on this date, ignoring the time value, essentially allowing you to filter by everything on a given day.