### PR TITLE
Bug fixes in QueryableExtensions

### DIFF
--- a/src/Extensions/QueryableExtension.cs
+++ b/src/Extensions/QueryableExtension.cs
@@ -44,11 +44,11 @@ public static class QueryableExtension
                     where.Append($" {prev.Trim()} ");
                 }
 
-                var property = opts[0];
+                var property = opts[0].Replace("\'", string.Empty);
                 var operand = opts[1];
                 var value = opts[2].Replace("'", "\"");
 
-                string? propertyName = typeof(T).GetProperties().FirstOrDefault(x => x.GetCustomAttribute<JsonPropertyNameAttribute>()?.Name == property)?.Name;
+                string? propertyName = typeof(T).GetProperties().FirstOrDefault(x => x.Name == property)?.Name;
 
                 if (!string.IsNullOrEmpty(propertyName))
                 {


### PR DESCRIPTION
This PR fixes 2 bugs in the QueryableExtensions class:

1. Allows for single quote mark in property name to prevent incorrectly splitting the query sting on keywords - example: property name `Vendor`, split on the keyword `or`.
2. Fix `propertyName` assigning logic (not working previously).