### PR TITLE
feat: Combined v2 Fixes - Enums, Null Safety, and ID Alias

### DIFF
--- a/src/GoatQuery/src/Ast/Literals.cs
+++ b/src/GoatQuery/src/Ast/Literals.cs
@@ -96,3 +96,13 @@ public sealed class BooleanLiteral : QueryExpression
         Value = value;
     }
 }
+
+public sealed class EnumSymbolLiteral : QueryExpression
+{
+    public string Value { get; set; }
+
+    public EnumSymbolLiteral(Token token, string value) : base(token)
+    {
+        Value = value;
+    }
+}

--- a/src/GoatQuery/src/Evaluator/FilterEvaluator.cs
+++ b/src/GoatQuery/src/Evaluator/FilterEvaluator.cs
@@ -167,7 +167,6 @@ public static class FilterEvaluator
                 return Result.Fail($"Invalid property '{segment}' in lambda expression property path");
 
             current = Expression.Property(current, propertyNode.ActualPropertyName);
-            if (!isLast)
             if (i < propertyPath.Segments.Count - 1)
             {
                 if (!propertyNode.HasNestedMapping)

--- a/src/GoatQuery/src/Parser/Parser.cs
+++ b/src/GoatQuery/src/Parser/Parser.cs
@@ -190,7 +190,7 @@ public sealed class QueryParser
 
         var statement = new InfixExpression(_currentToken, leftExpression, _currentToken.Literal);
 
-        if (!PeekTokenIn(TokenType.STRING, TokenType.INT, TokenType.GUID, TokenType.DATETIME, TokenType.DECIMAL, TokenType.FLOAT, TokenType.DOUBLE, TokenType.DATE, TokenType.NULL, TokenType.BOOLEAN))
+        if (!PeekTokenIn(TokenType.STRING, TokenType.INT, TokenType.GUID, TokenType.DATETIME, TokenType.DECIMAL, TokenType.FLOAT, TokenType.DOUBLE, TokenType.DATE, TokenType.NULL, TokenType.BOOLEAN, TokenType.IDENT))
         {
             return Result.Fail("Invalid value type within filter");
         }
@@ -295,6 +295,7 @@ public sealed class QueryParser
             TokenType.BOOLEAN => bool.TryParse(token.Literal, out var boolValue) 
                 ? new BooleanLiteral(token, boolValue) 
                 : null,
+            TokenType.IDENT => new EnumSymbolLiteral(token, token.Literal),
             _ => null
         };
     }

--- a/src/GoatQuery/src/Utilities/PropertyMappingTree.cs
+++ b/src/GoatQuery/src/Utilities/PropertyMappingTree.cs
@@ -23,7 +23,30 @@ public sealed class PropertyMappingTree
             return false;
         }
 
-        return ((Dictionary<string, PropertyMappingNode>)Properties).TryGetValue(jsonPropertyName, out node);
+        if (((Dictionary<string, PropertyMappingNode>)Properties).TryGetValue(jsonPropertyName, out node))
+        {
+            return true;
+        }
+
+        if (jsonPropertyName.EndsWith("Id", StringComparison.OrdinalIgnoreCase) && SourceType != null)
+        {
+            var typeName = SourceType.Name;
+            var expectedAlias = typeName + "Id";
+            if (jsonPropertyName.Equals(expectedAlias, StringComparison.OrdinalIgnoreCase))
+            {
+                foreach (var kvp in (Dictionary<string, PropertyMappingNode>)Properties)
+                {
+                    if (string.Equals(kvp.Value.ActualPropertyName, "Id", StringComparison.OrdinalIgnoreCase))
+                    {
+                        node = kvp.Value;
+                        return true;
+                    }
+                }
+            }
+        }
+
+        node = null;
+        return false;
     }
 
     internal void AddProperty(string jsonPropertyName, PropertyMappingNode node)

--- a/src/GoatQuery/src/Utilities/PropertyMappingTree.cs
+++ b/src/GoatQuery/src/Utilities/PropertyMappingTree.cs
@@ -172,11 +172,19 @@ public static class PropertyMappingTreeBuilder
 
     private static bool IsPrimitiveType(Type type)
     {
+        if (type.IsEnum)
+            return true;
+
         if (type.IsPrimitive || PrimitiveTypes.Contains(type))
             return true;
 
-        // Handle nullable types
         var underlyingType = Nullable.GetUnderlyingType(type);
-        return underlyingType != null && (underlyingType.IsPrimitive || PrimitiveTypes.Contains(underlyingType));
+        if (underlyingType == null)
+            return false;
+
+        if (underlyingType.IsEnum)
+            return true;
+
+        return underlyingType.IsPrimitive || PrimitiveTypes.Contains(underlyingType);
     }
 }

--- a/src/GoatQuery/tests/Filter/FilterParserTest.cs
+++ b/src/GoatQuery/tests/Filter/FilterParserTest.cs
@@ -23,6 +23,7 @@ public sealed class FilterParserTest
     [InlineData("dateOfBirth gte 2000-01-01", "dateOfBirth", "gte", "2000-01-01")]
     [InlineData("dateOfBirth eq 2023-01-30T09:29:55.1750906Z", "dateOfBirth", "eq", "2023-01-30T09:29:55.1750906Z")]
     [InlineData("balance eq null", "balance", "eq", "null")]
+    [InlineData("status eq Active", "status", "eq", "Active")]
     [InlineData("balance ne null", "balance", "ne", "null")]
     [InlineData("name eq NULL", "name", "eq", "NULL")]
     public void Test_ParsingFilterStatement(string input, string expectedLeft, string expectedOperator, string expectedRight)
@@ -168,6 +169,7 @@ public sealed class FilterParserTest
     [Theory]
     [InlineData("manager/firstName eq 'John'", new string[] { "manager", "firstName" }, "eq", "John")]
     [InlineData("manager/manager/firstName eq 'John'", new string[] { "manager", "manager", "firstName" }, "eq", "John")]
+    [InlineData("manager/status eq Active", new string[] { "manager", "status" }, "eq", "Active")]
     public void Test_ParsingFilterStatementWithNestedProperty(string input, string[] expectedLeft, string expectedOperator, string expectedRight)
     {
         var lexer = new QueryLexer(input);

--- a/src/GoatQuery/tests/Filter/FilterTest.cs
+++ b/src/GoatQuery/tests/Filter/FilterTest.cs
@@ -497,6 +497,119 @@ public sealed class FilterTest : IClassFixture<DatabaseTestFixture>
             "tags/all(x: x eq 'premium')",
             new[] { TestData.Users["Egg"] }
         };
+
+        // Status enum tests
+        yield return new object[] {
+            "status eq 'Active'",
+            new[] { TestData.Users["John"], TestData.Users["Apple"], TestData.Users["Doe"], TestData.Users["Egg"] }
+        };
+
+        yield return new object[] {
+            "status eq 'Inactive'",
+            new[] { TestData.Users["Jane"], TestData.Users["NullUser"] }
+        };
+
+        yield return new object[] {
+            "status eq 'Suspended'",
+            new[] { TestData.Users["Harry"] }
+        };
+
+        yield return new object[] {
+            "status ne 'Active'",
+            new[] { TestData.Users["Jane"], TestData.Users["Harry"], TestData.Users["NullUser"] }
+        };
+
+        yield return new object[] {
+            "status ne 'Inactive'",
+            new[] { TestData.Users["John"], TestData.Users["Apple"], TestData.Users["Harry"], TestData.Users["Doe"], TestData.Users["Egg"] }
+        };
+
+        yield return new object[] {
+            "status ne 'Suspended'",
+            new[] { TestData.Users["John"], TestData.Users["Jane"], TestData.Users["Apple"], TestData.Users["Doe"], TestData.Users["Egg"], TestData.Users["NullUser"] }
+        };
+
+        // Status combined with other properties
+        yield return new object[] {
+            "status eq 'Active' and age eq 1",
+            new[] { TestData.Users["Apple"], TestData.Users["Doe"] }
+        };
+
+        yield return new object[] {
+            "status eq 'Inactive' or age eq 33",
+            new[] { TestData.Users["Jane"], TestData.Users["Egg"], TestData.Users["NullUser"] }
+        };
+
+        yield return new object[] {
+            "status eq 'Active' and isEmailVerified eq true",
+            new[] { TestData.Users["John"], TestData.Users["Apple"], TestData.Users["Doe"] }
+        };
+
+        yield return new object[] {
+            "status ne 'Active' and age lt 10",
+            new[] { TestData.Users["Jane"], TestData.Users["Harry"], TestData.Users["NullUser"] }
+        };
+
+        // Manager status tests
+        yield return new object[] {
+            "manager/status eq 'Active'",
+            new[] { TestData.Users["John"], TestData.Users["Apple"], TestData.Users["Egg"] }
+        };
+
+        yield return new object[] {
+            "manager ne null and manager/status eq 'Active'",
+            new[] { TestData.Users["John"], TestData.Users["Apple"], TestData.Users["Egg"] }
+        };
+
+        yield return new object[] {
+            "status eq Active",
+            new[] { TestData.Users["John"], TestData.Users["Apple"], TestData.Users["Doe"], TestData.Users["Egg"] }
+        };
+
+        yield return new object[] {
+            "status eq Inactive",
+            new[] { TestData.Users["Jane"], TestData.Users["NullUser"] }
+        };
+
+        yield return new object[] {
+            "status eq Suspended",
+            new[] { TestData.Users["Harry"] }
+        };
+
+        yield return new object[] {
+            "status ne Active",
+            new[] { TestData.Users["Jane"], TestData.Users["Harry"], TestData.Users["NullUser"] }
+        };
+
+        yield return new object[] {
+            "status ne Inactive",
+            new[] { TestData.Users["John"], TestData.Users["Apple"], TestData.Users["Harry"], TestData.Users["Doe"], TestData.Users["Egg"] }
+        };
+
+        yield return new object[] {
+            "status ne Suspended",
+            new[] { TestData.Users["John"], TestData.Users["Jane"], TestData.Users["Apple"], TestData.Users["Doe"], TestData.Users["Egg"], TestData.Users["NullUser"] }
+        };
+
+        yield return new object[] {
+            "status eq Active and age eq 1",
+            new[] { TestData.Users["Apple"], TestData.Users["Doe"] }
+        };
+
+        yield return new object[] {
+            "status eq Active and isEmailVerified eq true",
+            new[] { TestData.Users["John"], TestData.Users["Apple"], TestData.Users["Doe"] }
+        };
+
+        yield return new object[] {
+            "manager/status eq Active",
+            new[] { TestData.Users["John"], TestData.Users["Apple"], TestData.Users["Egg"] }
+        };
+
+        yield return new object[] {
+            "manager ne null and manager/status eq Active",
+            new[] { TestData.Users["John"], TestData.Users["Apple"], TestData.Users["Egg"] }
+        };
     }
 
     [Theory]
@@ -521,6 +634,7 @@ public sealed class FilterTest : IClassFixture<DatabaseTestFixture>
     [InlineData("addresses/any(addr: addr/nonExistentProperty eq 'test')")]
     [InlineData("addresses/invalid(addr: addr/city/name eq 'test')")]
     [InlineData("nonExistentCollection/any(item: item eq 'test')")]
+    [InlineData("firstname eq John")] // Unquoted RHS on non-enum should error
     public void Test_InvalidFilterReturnsError(string filter)
     {
         var query = new Query

--- a/src/GoatQuery/tests/Filter/FilterTest.cs
+++ b/src/GoatQuery/tests/Filter/FilterTest.cs
@@ -102,6 +102,11 @@ public sealed class FilterTest : IClassFixture<DatabaseTestFixture>
         };
 
         yield return new object[] {
+            "userid eq e4c7772b-8947-4e46-98ed-644b417d2a08 or id eq 01998fda-e310-793c-bd8d-f6a92f87b31b",
+            new[] { TestData.Users["Jane"], TestData.Users["Harry"] }
+        };
+
+        yield return new object[] {
             "age lt 3",
             new[] { TestData.Users["John"], TestData.Users["Apple"], TestData.Users["Harry"], TestData.Users["Doe"] }
         };

--- a/src/GoatQuery/tests/TestData.cs
+++ b/src/GoatQuery/tests/TestData.cs
@@ -1,5 +1,16 @@
 public static class TestData
 {
+    private static readonly User Manager01 = new User
+    {
+        Id = Guid.Parse("671e6bac-b6de-4cc7-b3e9-1a6ac4546b43"),
+        Age = 16,
+        Firstname = "Manager 01",
+        DateOfBirth = DateTime.Parse("2000-01-01 00:00:00").ToUniversalTime(),
+        BalanceDecimal = 2.00m,
+        IsEmailVerified = false,
+        Status = Status.Active
+    };
+
     public static readonly Dictionary<string, User> Users = new Dictionary<string, User>
     {
         ["John"] = new User
@@ -23,18 +34,11 @@ public static class TestData
                     City = new City { Name = "Boston", Country = "USA" }
                 }
             },
-            Manager = new User
-            {
-                Age = 16,
-                Firstname = "Manager 01",
-                DateOfBirth = DateTime.Parse("2000-01-01 00:00:00").ToUniversalTime(),
-                BalanceDecimal = 2.00m,
-                IsEmailVerified = false,
-                Status = Status.Active
-            }
+            Manager = Manager01
         },
         ["Jane"] = new User
         {
+            Id = Guid.Parse("01998fda-e310-793c-bd8d-f6a92f87b31b"),
             Age = 9,
             Firstname = "Jane",
             DateOfBirth = DateTime.Parse("2020-05-09 15:30:00").ToUniversalTime(),
@@ -76,19 +80,12 @@ public static class TestData
                     City = new City { Name = "New York", Country = "USA" }
                 }
             },
-            Manager = new User
-            {
-                Age = 16,
-                Firstname = "Manager 01",
-                DateOfBirth = DateTime.Parse("2000-01-01 00:00:00").ToUniversalTime(),
-                BalanceDecimal = 2.00m,
-                IsEmailVerified = true,
-                Status = Status.Active
-            },
+            Manager = Manager01,
             Tags = ["vip", "premium"]
         },
         ["Harry"] = new User
         {
+            Id = Guid.Parse("e4c7772b-8947-4e46-98ed-644b417d2a08"),
             Age = 1,
             Firstname = "Harry",
             DateOfBirth = DateTime.Parse("2002-08-01").ToUniversalTime(),

--- a/src/GoatQuery/tests/TestData.cs
+++ b/src/GoatQuery/tests/TestData.cs
@@ -9,6 +9,7 @@ public static class TestData
             DateOfBirth = DateTime.Parse("2004-01-31 23:59:59").ToUniversalTime(),
             BalanceDecimal = 1.50m,
             IsEmailVerified = true,
+            Status = Status.Active,
             Addresses = new[]
             {
                 new Address
@@ -28,7 +29,8 @@ public static class TestData
                 Firstname = "Manager 01",
                 DateOfBirth = DateTime.Parse("2000-01-01 00:00:00").ToUniversalTime(),
                 BalanceDecimal = 2.00m,
-                IsEmailVerified = false
+                IsEmailVerified = false,
+                Status = Status.Active
             }
         },
         ["Jane"] = new User
@@ -38,6 +40,7 @@ public static class TestData
             DateOfBirth = DateTime.Parse("2020-05-09 15:30:00").ToUniversalTime(),
             BalanceDecimal = 0,
             IsEmailVerified = false,
+            Status = Status.Inactive,
             Addresses = new[]
             {
                 new Address
@@ -59,6 +62,7 @@ public static class TestData
             DateOfBirth = DateTime.Parse("1980-12-31 00:00:01").ToUniversalTime(),
             BalanceFloat = 1204050.98f,
             IsEmailVerified = true,
+            Status = Status.Active,
             Addresses = new[]
             {
                 new Address
@@ -78,7 +82,8 @@ public static class TestData
                 Firstname = "Manager 01",
                 DateOfBirth = DateTime.Parse("2000-01-01 00:00:00").ToUniversalTime(),
                 BalanceDecimal = 2.00m,
-                IsEmailVerified = true
+                IsEmailVerified = true,
+                Status = Status.Active
             },
             Tags = ["vip", "premium"]
         },
@@ -89,6 +94,7 @@ public static class TestData
             DateOfBirth = DateTime.Parse("2002-08-01").ToUniversalTime(),
             BalanceDecimal = 0.5372958205929493m,
             IsEmailVerified = false,
+            Status = Status.Suspended,
             Addresses = Array.Empty<Address>()
         },
         ["Doe"] = new User
@@ -98,6 +104,7 @@ public static class TestData
             DateOfBirth = DateTime.Parse("2023-07-26 12:00:30").ToUniversalTime(),
             BalanceDecimal = null,
             IsEmailVerified = true,
+            Status = Status.Active,
             Addresses = new[]
             {
                 new Address
@@ -114,6 +121,7 @@ public static class TestData
             DateOfBirth = DateTime.Parse("2000-01-01 00:00:00").ToUniversalTime(),
             BalanceDouble = 1334534453453433.33435443343231235652d,
             IsEmailVerified = false,
+            Status = Status.Active,
             Addresses = new[]
             {
                 new Address
@@ -134,6 +142,7 @@ public static class TestData
                 DateOfBirth = DateTime.Parse("1999-04-21 00:00:00").ToUniversalTime(),
                 BalanceDecimal = 19.00m,
                 IsEmailVerified = true,
+                Status = Status.Active,
                 Manager = new User
                 {
                     Age = 30,
@@ -141,13 +150,15 @@ public static class TestData
                     DateOfBirth = DateTime.Parse("1993-04-21 00:00:00").ToUniversalTime(),
                     BalanceDecimal = 29.00m,
                     IsEmailVerified = true,
+                    Status = Status.Active,
                     Manager = new User
                     {
                         Age = 40,
                         Firstname = "Manager 04",
                         DateOfBirth = DateTime.Parse("1983-04-21 00:00:00").ToUniversalTime(),
                         BalanceDecimal = 39.00m,
-                        IsEmailVerified = true
+                        IsEmailVerified = true,
+                        Status = Status.Active
                     },
                     Company = new Company
                     {
@@ -167,6 +178,7 @@ public static class TestData
             BalanceDouble = null,
             BalanceFloat = null,
             IsEmailVerified = true,
+            Status = Status.Inactive,
             Addresses = Array.Empty<Address>()
         },
     };

--- a/src/GoatQuery/tests/User.cs
+++ b/src/GoatQuery/tests/User.cs
@@ -10,6 +10,7 @@ public record User
     public float? BalanceFloat { get; set; }
     public DateTime? DateOfBirth { get; set; }
     public bool IsEmailVerified { get; set; }
+    public Status Status { get; set; }
     public Company? Company { get; set; }
     public User? Manager { get; set; }
     public IEnumerable<Address> Addresses { get; set; } = Array.Empty<Address>();
@@ -41,4 +42,12 @@ public record Company
     public Guid Id { get; set; }
     public string Name { get; set; } = string.Empty;
     public string Department { get; set; } = string.Empty;
+}
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum Status
+{
+    Active,
+    Inactive,
+    Suspended
 }


### PR DESCRIPTION
# Combined v2 Fixes: Enums, Null Safety, and ID Alias

This PR combines the changes from three separate PRs to provide a single, comprehensive update that addresses multiple v2 filter improvements:

## Included Changes

### 1. Enum Support (from #99)
- Added support for enum values in filter queries
- Allows both quoted and unquoted enum symbols to be parsed and evaluated correctly
- Introduces a new `EnumSymbolLiteral` AST node
- Updates parser and evaluator logic to handle enums
- Extends test coverage to verify enum filtering functionality

### 2. Null Safety Improvements (from #100)
- Enhanced null safety in the filter evaluator
- Improved handling of nullable properties throughout the evaluation chain
- Better error handling for null reference scenarios

### 3. ID Alias Fix (from #101)  
- Fixed issues with property aliases, particularly for ID fields
- Improved property mapping to handle both standard and aliased property names correctly
- Ensures proper resolution of property paths when aliases are used

## Related PRs
This PR combines the following individual PRs:
- #99: feat: v2 Enums
- #100: fix: v2 null safety
- #101: fix: v2 id alias

## Testing
All changes have been tested together and include comprehensive test coverage for:
- Enum filtering with various status values
- Null safety scenarios with nested properties
- Property alias resolution, especially for ID fields

The individual PRs remain available if you prefer to review and merge them separately.